### PR TITLE
Update 240704

### DIFF
--- a/Missionframework/KPLIB_classnameLists.sqf
+++ b/Missionframework/KPLIB_classnameLists.sqf
@@ -114,8 +114,22 @@ KPLIB_medical_facilities = [
     "US_Tent_MASH"
 ];
 
+// Building classnames which also function as ACE repair facilities.
+KPLIB_repair_facilities = [
+    "Land_RepairDepot_01_green_F",
+    "Land_RepairDepot_01_tan_F",
+    "Land_Workbench_01_F"
+];
+
 // Classnames of ACE crates
 KPLIB_ace_crates = [
+    "APR_MREBox_GreenTea",
+    "APR_MREBox_Water",
+    "APR_MREBox_IDAP",
+    "APR_MREBox_MRE",
+    "APR_MREBox_JP",
+    "APR_MREBox_ALL",
+    
     "BWA3_box_120mm_Mo_Combo",
     "BWA3_box_120mm_Mo_HE",
     "BWA3_box_120mm_Mo_HE_annz",
@@ -220,7 +234,6 @@ vehicle_repair_sources = [
     "O_Heli_Transport_04_repair_F",
     "O_T_Truck_03_repair_ghex_F",
     "O_Truck_03_repair_F",
-    "Land_Workbench_01_F",
     "RHS_Ural_Repair_VDV_01",
     "rhsusf_M1078A1R_SOV_M2_D_fmtv_socom",
     "rhsusf_M1239_M2_Deploy_socom_d",

--- a/Missionframework/KPLIB_classnameLists.sqf
+++ b/Missionframework/KPLIB_classnameLists.sqf
@@ -358,6 +358,8 @@ vehicle_refuel_sources = [
 
 // Classnames of boats, so they can be built on water.
 boats_names = [
+    "sab_mp_rhib",
+    "sab_mp_migaloo",
     "B_Boat_Armed_01_minigun_F",
     "C_Scooter_Transport_01_F",
     "B_Boat_Transport_01_F",

--- a/Missionframework/KPLIB_objectInits.sqf
+++ b/Missionframework/KPLIB_objectInits.sqf
@@ -185,6 +185,14 @@ KPLIB_objectInits = [
         }
     ],
 
+    // Set MH47 Probe
+    [
+        ["CUP_B_MH47E_USA"],
+        {
+            [_this,nil,["Hide_Probe",0]] call BIS_fnc_initVehicle;
+        }
+    ],
+
     // Disable autocombat (if set in parameters) and fleeing
     [
         ["CAManBase"],

--- a/Missionframework/KPLIB_objectInits.sqf
+++ b/Missionframework/KPLIB_objectInits.sqf
@@ -125,7 +125,7 @@ KPLIB_objectInits = [
             [_this] spawn {
                 params ["_fuelTruck"];
                 waitUntil {sleep 0.1; time > 0};
-                if (getNumber (configfile >> "CfgVehicles" >> (typeOf _fuelTruck) >> "ace_refuel_fuelCargo") > 0) then {
+                if (getNumber (configfile >> "CfgVehicles" >> (typeOf _fuelTruck) >> "ace_refuel_fuelCargo") <= 0) then {
                     [_fuelTruck, 3000] remoteExecCall ["ace_refuel_fnc_makeSource", 0, _fuelTruck];
                 };
             };

--- a/Missionframework/KPLIB_objectInits.sqf
+++ b/Missionframework/KPLIB_objectInits.sqf
@@ -96,10 +96,18 @@ KPLIB_objectInits = [
         }
     ],
     
-    // Add ACE variables to corresponding building types
+    // Add ACE variables to corresponding building/vehicle types
     [
-        [KPLIB_b_logiStation],
+        KPLIB_repair_facilities + [KPLIB_b_logiStation],
         {_this setVariable ["ace_isRepairFacility", 1, true];}
+    ],
+    [
+        vehicle_repair_sources,
+        {_this setVariable ["ace_isRepairVehicle", 1, true];}
+    ],
+    [
+        vehicle_rearm_sources,
+        {_this setVariable ["ace_rearm_isSupplyVehicle", true, true];}
     ],
     [
         KPLIB_medical_facilities,
@@ -108,6 +116,20 @@ KPLIB_objectInits = [
     [
         KPLIB_medical_vehicles,
         {_this setVariable ["ace_medical_isMedicalVehicle", true, true];}
+    ],
+
+    // Add ACE refuel function to corresponding building/vehicle types when ace fuelCargo config is missing
+    [
+        vehicle_refuel_sources,
+        {
+            [_this] spawn {
+                params ["_fuelTruck"];
+                waitUntil {sleep 0.1; time > 0};
+                if (getNumber (configfile >> "CfgVehicles" >> (typeOf _fuelTruck) >> "ace_refuel_fuelCargo") > 0) then {
+                    [_fuelTruck, 3000] remoteExecCall ["ace_refuel_fnc_makeSource", 0, _fuelTruck];
+                };
+            };
+        }
     ],
 
     // Hide Cover on big GM trucks
@@ -146,14 +168,6 @@ KPLIB_objectInits = [
                 waitUntil {sleep 0.1; time > 0};
                 [_medvacbox] remoteExecCall ["KPLIB_fnc_addActionsFullHeal", 0, _medvacbox];
             };
-        }
-    ],
-
-    // Add VAM Workbench repairFacility compat in case it doesn't work the other way
-    [
-        ["Land_Workbench_01_F"], 
-        {
-            _this setVariable ["ace_isRepairFacility", 1, true];
         }
     ],
 

--- a/Missionframework/functions/fn_crGlobalMsg.sqf
+++ b/Missionframework/functions/fn_crGlobalMsg.sqf
@@ -28,8 +28,9 @@ switch (_msgType) do {
     case 1: {systemChat (format [localize "STR_CR_BUILDINGMSG", (_data select 0)]);};
     case 2: {systemChat (format [localize "STR_CR_KILLMSG", (_data select 0), (_data select 1)]);};
     case 3: {systemChat (format [localize "STR_CR_RESISTANCE_KILLMSG", (_data select 0), (_data select 1)]);};
-    case 4: {systemChat (format [localize "STR_CR_HEALMSG", (_data select 0)]);};
+    case 4: {systemChat (format [localize "STR_CR_HEALMSG", (_data select 0), (_data select 1)]);};
     case 5: {["lib_asymm_guerilla_incoming", _data] call BIS_fnc_showNotification;};
+    case 6: {systemChat (format [localize "STR_CR_HELPMSG", (_data select 0), (_data select 1)]);};
     default {[format ["globalMsg without valid msgType - %1", _msgType], "CIVREP"] remoteExecCall ["KPLIB_fnc_log", 2];};
 };
 

--- a/Missionframework/init.sqf
+++ b/Missionframework/init.sqf
@@ -24,7 +24,7 @@ if (!isServer) then {waitUntil {!isNil "KPLIB_initServerDone"};};
 if (!KPPLM_CBA) then {
     ["CBA_A3 not loaded. Aborting Mission! KPLib_APR requires CBA!!!"] call BIS_fnc_error;
     ["CBA_A3 not loaded. This mission requires CBA to run properly."] remoteExec ["hint", 0, true];
-	sleep 1;
+    sleep 1;
     endMission "END2";
     false;
 };

--- a/Missionframework/scripts/client/civinformant/civinfo_escort.sqf
+++ b/Missionframework/scripts/client/civinformant/civinfo_escort.sqf
@@ -2,6 +2,8 @@ scriptName "civinfo_escort";
 
 params ["_informant"];
 
+waitUntil {sleep 0.5; local _unit};
+
 if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_escort called on: %1 - Parameters: [%2]", debug_source, _informant], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
 
 private _is_near_fob = false;

--- a/Missionframework/scripts/client/civinformant/civinfo_escort.sqf
+++ b/Missionframework/scripts/client/civinformant/civinfo_escort.sqf
@@ -2,8 +2,6 @@ scriptName "civinfo_escort";
 
 params ["_informant"];
 
-if (isDedicated) exitWith {};
-
 if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_escort called on: %1 - Parameters: [%2]", debug_source, _informant], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
 
 private _is_near_fob = false;
@@ -25,9 +23,9 @@ if (alive _informant) then {
         if (KPLIB_ace) then {
             private _isCuffed = _informant getVariable ["ace_captives_isHandcuffed", false];
             if (_isCuffed) then {
-                ["ace_captives_setHandcuffed", [_informant, false], _informant] call CBA_fnc_targetEvent;
+                ["ace_captives_setHandcuffed", [_informant, false], _informant] remoteExecCall ["CBA_fnc_targetEvent", 2];
             } else {
-                ["ace_captives_setSurrendered", [_informant, false], _informant] call CBA_fnc_targetEvent;
+                ["ace_captives_setSurrendered", [_informant, false], _informant] remoteExecCall ["CBA_fnc_targetEvent", 2];
             };
             sleep 1;
         };
@@ -38,12 +36,10 @@ if (alive _informant) then {
         [_informant, "AidlPsitMstpSnonWnonDnon_ground00"] remoteExecCall ["switchMove"];
         [_informant] remoteExec ["civinfo_delivered",2];
         if (KPLIB_civinfo_debug > 0) then {["civinfo_escort -> Informant at FOB", "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
-        _informant setVariable ["KPLIB_civinfo_under_control", false, true];
+        KPLIB_civinfo_under_control = true;
         sleep 600;
         if (isNull objectParent _informant) then {deleteVehicle _informant} else {(objectParent _informant) deleteVehicleCrew _informant};
         if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_escort finished by: %1", debug_source], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
     };
-} else {
-    if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_escort exited by: %1 - Informant isn't alive", debug_source], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
-    [3] remoteExec ["civinfo_notifications"];
 };
+KPLIB_civinfo_under_control = false;

--- a/Missionframework/scripts/client/civinformant/civinfo_notifications.sqf
+++ b/Missionframework/scripts/client/civinformant/civinfo_notifications.sqf
@@ -13,9 +13,9 @@ switch (_notif_id) do {
         
         private _informant_zone = createMarkerLocal ["informantzone", _pos];
         _informant_zone setMarkerColorLocal "ColorCIV";
-        _informant_zone setMarkerShape "ELLIPSE";
-        _informant_zone setMarkerBrush "FDiagonal";
-        _informant_zone setMarkerSize [75,75];
+        _informant_zone setMarkerShapeLocal "ELLIPSE";
+        _informant_zone setMarkerBrushLocal "FDiagonal";
+        _informant_zone setMarkerSizeLocal [150,150];
     };
     case 1: {
         ["lib_civ_informant_success"] call BIS_fnc_showNotification;
@@ -34,15 +34,15 @@ switch (_notif_id) do {
     };
     case 4: {
         ["lib_civ_hvt_start", [markertext ([10000, _pos] call KPLIB_fnc_getNearestSector)]] call BIS_fnc_showNotification;
-        private _marker = createMarker ["HVT_marker", _pos];
-        _marker setMarkerColor KPLIB_color_enemyActive;
-        _marker setMarkerType "hd_unknown";
+        private _marker = createMarkerLocal ["HVT_marker", _pos];
+        _marker setMarkerColorLocal KPLIB_color_enemyActive;
+        _marker setMarkerTypeLocal "hd_unknown";
 
-        private _marker_zone = createMarker ["HVT_zone", _pos];
-        _marker_zone setMarkerColor KPLIB_color_enemyActive;
-        _marker_zone setMarkerShape "ELLIPSE";
-        _marker_zone setMarkerBrush "FDiagonal";
-        _marker_zone setMarkerSize [500,500];
+        private _marker_zone = createMarkerLocal ["HVT_zone", _pos];
+        _marker_zone setMarkerColorLocal KPLIB_color_enemyActive;
+        _marker_zone setMarkerShapeLocal "ELLIPSE";
+        _marker_zone setMarkerBrushLocal "FDiagonal";
+        _marker_zone setMarkerSizeLocal [500,500];
     };
     case 5: {
         ["lib_civ_hvt_success"] call BIS_fnc_showNotification;

--- a/Missionframework/scripts/client/markers/empty_vehicles_marker.sqf
+++ b/Missionframework/scripts/client/markers/empty_vehicles_marker.sqf
@@ -16,6 +16,7 @@ _support_to_skip = [
     "B_Slingload_01_Fuel_F",
     "B_Slingload_01_Ammo_F"
 ];
+_support_to_skip = _support_to_skip apply {toLowerANSI _x};
 
 {
     _vehtomark append _x;

--- a/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
+++ b/Missionframework/scripts/client/remotecall/remote_call_prisonner.sqf
@@ -42,9 +42,9 @@ if (alive _unit) then {
         if (KPLIB_ace) then {
             private _isCuffed = _unit getVariable ["ace_captives_isHandcuffed", false];
             if (_isCuffed) then {
-                ["ace_captives_setHandcuffed", [_unit, false], _unit] call CBA_fnc_targetEvent;
+                ["ace_captives_setHandcuffed", [_unit, false], _unit] remoteExecCall ["CBA_fnc_targetEvent", 2];
             } else {
-                ["ace_captives_setSurrendered", [_unit, false], _unit] call CBA_fnc_targetEvent;
+                ["ace_captives_setSurrendered", [_unit, false], _unit] remoteExecCall ["CBA_fnc_targetEvent", 2];
             };
             sleep 1;
         };

--- a/Missionframework/scripts/server/ai/building_defence_ai.sqf
+++ b/Missionframework/scripts/server/ai/building_defence_ai.sqf
@@ -2,46 +2,96 @@ scriptName "building_defence_ai";
 
 params ["_unit", ["_sector", ""]];
 
+private _sectorPos = (markerPos _sector);
 //Check LAMBS_Danger.fsm is running. if running, skip KPLIB built in troop garrisoning and call lambs wp garrisoning.
-if (isClass (configfile >> "CfgPatches" >> "lambs_wp")) exitWith {[_unit, _unit, 40, [], false, false, -1, false] call lambs_wp_fnc_taskGarrison;};
+if (isClass (configfile >> "CfgPatches" >> "lambs_wp")) then {
+    [_unit, _sectorPos, (KPLIB_range_sectorCapture / 3 * 2), [], true, false, -1, false] call lambs_wp_fnc_taskGarrison;
 
-_unit setUnitPos "UP";
-_unit disableAI "PATH";
-private _move_is_disabled = true;
-private _hostiles = 0;
-private _ratio = 0.4;
-private _range = 40;
+    private _move_is_disabled = true;
+    private _hostiles = 0;
+    private _ratio = 0.4;
+    private _range = 40;
 
-while {_move_is_disabled && local _unit && alive _unit && !(captive _unit)} do {
+    while {_move_is_disabled && local _unit && alive _unit && !(captive _unit)} do {
 
-    if !(_sector isEqualTo "") then {
-        _ratio = [_sector] call KPLIB_fnc_getBluforRatio;
-    };
-
-    _range = floor (linearConversion [0, 1, _ratio, 0, KPLIB_range_sectorCapture / 3 * 2, true]);
-
-    _hostiles = (_unit nearEntities [["CAManBase"], _range]) select {side _x == KPLIB_side_player};
-
-    if (_move_is_disabled &&
-        {
-            (_sector in KPLIB_sectors_player) ||
-            {!(_hostiles isEqualTo [])} ||
-            {damage _unit > 0.25}
-        }
-    ) then {
-        _move_is_disabled = false;
-        _unit enableAI "PATH";
-        _unit setUnitPos "AUTO";
-    };
-
-    if (_move_is_disabled) then {
-        private _target = assignedTarget _unit;
-        if(!(isnull _target)) then {
-            private _vd = (getPosASL _target) vectorDiff (getpos _unit);
-            private _newdir = (_vd select 0) atan2 (_vd select 1);
-            if (_newdir < 0) then {_dir = 360 + _newdir};
-            _unit setdir (_newdir);
+        if !(_sector isEqualTo "") then {
+            _ratio = [_sector] call KPLIB_fnc_getBluforRatio;
         };
+
+        _range = floor (linearConversion [0, 1, _ratio, 0, KPLIB_range_sectorCapture / 3 * 2, true]);
+
+        _hostiles = (_unit nearEntities [["CAManBase"], _range]) select {side _x == KPLIB_side_player};
+
+        if (_move_is_disabled &&
+            {
+                (_sector in KPLIB_sectors_player) ||
+                {!(_hostiles isEqualTo [])} ||
+                {damage _unit > 0.25}
+            }
+        ) then {
+            _move_is_disabled = false;
+            if (KPLIB_ace) then {
+                [_unit] call ace_ai_fnc_unGarrison;
+            } else {
+                _unit enableAI "PATH";
+                _unit setUnitPos "AUTO";
+            };
+        };
+
+        if (_move_is_disabled) then {
+            private _target = assignedTarget _unit;
+            if(!(isnull _target)) then {
+                private _vd = (getPosASL _target) vectorDiff (getpos _unit);
+                private _newdir = (_vd select 0) atan2 (_vd select 1);
+                if (_newdir < 0) then {_dir = 360 + _newdir};
+                _unit setdir (_newdir);
+            };
+        };
+        sleep 5;
     };
-    sleep 5;
+} else {
+    _unit setUnitPos "UP";
+    _unit disableAI "PATH";
+    private _move_is_disabled = true;
+    private _hostiles = 0;
+    private _ratio = 0.4;
+    private _range = 40;
+
+    while {_move_is_disabled && local _unit && alive _unit && !(captive _unit)} do {
+
+        if !(_sector isEqualTo "") then {
+            _ratio = [_sector] call KPLIB_fnc_getBluforRatio;
+        };
+
+        _range = floor (linearConversion [0, 1, _ratio, 0, KPLIB_range_sectorCapture / 3 * 2, true]);
+
+        _hostiles = (_unit nearEntities [["CAManBase"], _range]) select {side _x == KPLIB_side_player};
+
+        if (_move_is_disabled &&
+            {
+                (_sector in KPLIB_sectors_player) ||
+                {!(_hostiles isEqualTo [])} ||
+                {damage _unit > 0.25}
+            }
+        ) then {
+            _move_is_disabled = false;
+            if (KPLIB_ace) then {
+                [_unit] call ace_ai_fnc_unGarrison;
+            } else {
+                _unit enableAI "PATH";
+                _unit setUnitPos "AUTO";
+            };
+        };
+
+        if (_move_is_disabled) then {
+            private _target = assignedTarget _unit;
+            if(!(isnull _target)) then {
+                private _vd = (getPosASL _target) vectorDiff (getpos _unit);
+                private _newdir = (_vd select 0) atan2 (_vd select 1);
+                if (_newdir < 0) then {_dir = 360 + _newdir};
+                _unit setdir (_newdir);
+            };
+        };
+        sleep 5;
+    };
 };

--- a/Missionframework/scripts/server/ai/prisonner_ai.sqf
+++ b/Missionframework/scripts/server/ai/prisonner_ai.sqf
@@ -25,7 +25,7 @@ if ((side group _unit == KPLIB_side_enemy) && (_unit isKindOf "CAManBase") && (a
         _unit setVariable ["KPLIB_prisonner_surrendered", true, true];
 
         if (KPLIB_ace) then {
-            ["ace_captives_setSurrendered", [_unit, true], _unit] call CBA_fnc_targetEvent;
+            ["ace_captives_setSurrendered", [_unit, true], _unit] remoteExecCall ["CBA_fnc_targetEvent", 2];
         } else {
             _unit disableAI "ANIM";
             _unit disableAI "MOVE";
@@ -61,7 +61,7 @@ if ((side group _unit == KPLIB_side_enemy) && (_unit isKindOf "CAManBase") && (a
                 if (_isCuffed) then {
                     _unit setVariable ["KPLIB_prisonner_captured", true, true];
                 } else {
-                    ["ace_captives_setSurrendered", [_unit, false], _unit] call CBA_fnc_targetEvent;
+                    ["ace_captives_setSurrendered", [_unit, false], _unit] remoteExecCall ["CBA_fnc_targetEvent", 2];
                 };
             } else {
                 _unit setCaptive false;

--- a/Missionframework/scripts/server/battlegroup/random_battlegroups.sqf
+++ b/Missionframework/scripts/server/battlegroup/random_battlegroups.sqf
@@ -24,6 +24,6 @@ while {KPLIB_param_aggressivity > 0.9 && KPLIB_endgame == 0} do {
         && {[] call KPLIB_fnc_getOpforCap < KPLIB_cap_battlegroup}
         && {diag_fps > 15.0}
     ) then {
-        ["", (random 100) < 45] spawn spawn_battlegroup;
+        ["", (random 100) < 15] spawn spawn_battlegroup;
     };
 };

--- a/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
+++ b/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
@@ -87,20 +87,6 @@ while {true} do {
         private _isCuffed = _informant getVariable ["ace_captives_isHandcuffed", false];
         KPLIB_civinfo_under_control = false;
         if (_isCaptured || _isCuffed) then {
-            if (KPLIB_ace) then {
-                private _isCuffed = _informant getVariable ["ace_captives_isHandcuffed", false];
-                if !(_isCuffed) then {
-                    ["ace_captives_setSurrendered", [_informant, false], _informant] remoteExecCall ["CBA_fnc_targetEvent", 2];
-                };
-            } else {
-                _informant setCaptive false;
-                _informant enableAI "ANIM";
-                _informant enableAI "MOVE";
-                sleep 1;
-                _informant playmove "AmovPercMstpSsurWnonDnon_AmovPercMstpSnonWnonDnon";
-                sleep 2;
-            };
-            
             private _capturedPlayer = _informant getVariable ["KPLIB_prisonner_whois", objNull];
             if (isNull _capturedPlayer) then {
                 private _players = allPlayers;
@@ -116,13 +102,25 @@ while {true} do {
                 _CapturedPlayer = _nearestPlayer;
             };
             _informant setVariable ["KPLIB_prisonner_whois", _capturedPlayer];
-            group _informant setGroupOwner owner _capturedPlayer;
             [[_informant], group _capturedPlayer] remoteExecCall ["joinSilent"];
+            if (KPLIB_ace) then {
+                private _isCuffed = _informant getVariable ["ace_captives_isHandcuffed", false];
+                if !(_isCuffed) then {
+                    ["ace_captives_setSurrendered", [_informant, false], _informant] remoteExecCall ["CBA_fnc_targetEvent", 2];
+                };
+            } else {
+                _informant setCaptive false;
+                _informant enableAI "ANIM";
+                _informant enableAI "MOVE";
+                sleep 1;
+                _informant playmove "AmovPercMstpSsurWnonDnon_AmovPercMstpSnonWnonDnon";
+                sleep 2;
+            };
             if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_loop civilian joined to group: %1", name _capturedPlayer], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
             doStop _informant;
             _informant doFollow _capturedPlayer;
 
-            [_informant] remoteExec ["civinfo_escort",2];
+            [_informant] remoteExec ["civinfo_escort", _informant];
             [7, [0,0,0], _capturedPlayer] remoteExec ["civinfo_notifications"];
         };
         

--- a/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
+++ b/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
@@ -37,7 +37,7 @@ while {true} do {
         sleep 1;
         
         if (KPLIB_ace) then {
-            ["ace_captives_setSurrendered", [_informant, true], _informant] call CBA_fnc_targetEvent;
+            ["ace_captives_setSurrendered", [_informant, true], _informant] remoteExecCall ["CBA_fnc_targetEvent", 2];
         } else {
             _informant disableAI "ANIM";
             _informant disableAI "MOVE";
@@ -49,7 +49,7 @@ while {true} do {
 
         if (KPLIB_civinfo_debug > 0) then {[format ["Informant %1 spawned on: %2 - Position: %3", name _informant, debug_source, getPos _informant], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
 
-        [0, [((((getPos _informant) select 0) + 35) - random 70),((((getPos _informant) select 1) + 35) - random 70),0]] remoteExec ["civinfo_notifications"];
+        [0, [((((getPos _informant) select 0) + 125) - random 250),((((getPos _informant) select 1) + 125) - random 250),0]] remoteExec ["civinfo_notifications"];
 
         // Time-based despawn
         private _time_start = time;
@@ -58,17 +58,6 @@ while {true} do {
             (alive _informant && ((time - _time_start) < _waiting_time))
         } do {
             uiSleep 1;
-            
-            private _isCaptured = _informant getVariable ["KPLIB_prisonner_captured", false];
-            private _isCuffed = _informant getVariable ["ace_captives_isHandcuffed", false];
-            if (_isCaptured || _isCuffed) exitWith {};
-            
-            if (KPLIB_ace) then {
-                private _isSurrendering = _informant getVariable ["ace_captives_isSurrendering", false];
-                if !(_isSurrendering) then {
-                    ["ace_captives_setSurrendered", [_informant, true], _informant] call CBA_fnc_targetEvent;
-                };
-            };
             
             _player_not_near = true;
             {
@@ -81,6 +70,10 @@ while {true} do {
                     [format ["Informant will despawn in %1 minutes", round (_waiting_time / 60)], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];
                 };
             };
+            
+            private _isCaptured = _informant getVariable ["KPLIB_prisonner_captured", false];
+            private _isCuffed = _informant getVariable ["ace_captives_isHandcuffed", false];
+            if (_isCaptured || _isCuffed) exitWith {};
         };
         if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_loop Countdown exit"], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
         
@@ -92,11 +85,12 @@ while {true} do {
         
         private _isCaptured = _informant getVariable ["KPLIB_prisonner_captured", false];
         private _isCuffed = _informant getVariable ["ace_captives_isHandcuffed", false];
+        KPLIB_civinfo_under_control = false;
         if (_isCaptured || _isCuffed) then {
             if (KPLIB_ace) then {
                 private _isCuffed = _informant getVariable ["ace_captives_isHandcuffed", false];
                 if !(_isCuffed) then {
-                    ["ace_captives_setSurrendered", [_informant, false], _informant] call CBA_fnc_targetEvent;
+                    ["ace_captives_setSurrendered", [_informant, false], _informant] remoteExecCall ["CBA_fnc_targetEvent", 2];
                 };
             } else {
                 _informant setCaptive false;
@@ -121,24 +115,25 @@ while {true} do {
                 } forEach _players;
                 _CapturedPlayer = _nearestPlayer;
             };
+            _informant setVariable ["KPLIB_prisonner_whois", _capturedPlayer];
+            group _informant setGroupOwner owner _capturedPlayer;
             [[_informant], group _capturedPlayer] remoteExecCall ["joinSilent"];
             if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_loop civilian joined to group: %1", name _capturedPlayer], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
             doStop _informant;
             _informant doFollow _capturedPlayer;
 
-            [_informant] remoteExec ["civinfo_escort"];
+            [_informant] remoteExec ["civinfo_escort",2];
             [7, [0,0,0], _capturedPlayer] remoteExec ["civinfo_notifications"];
-            _informant setVariable ["KPLIB_civinfo_under_control", true, true];
         };
         
-        waitUntil {!alive _informant || _timeover || !(_informant getVariable ["KPLIB_civinfo_under_control", false])};
+        waitUntil {!alive _informant || _timeover};
         
-        if (!(_informant getVariable ["KPLIB_civinfo_under_control", false]) && _timeover) exitWith {
+        if (_timeover) exitWith {
             if (isNull objectParent _informant) then {deleteVehicle _informant} else {(objectParent _informant) deleteVehicleCrew _informant};
             if (KPLIB_civinfo_debug > 0) then {["Informant despawned", "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
             [2] remoteExec ["civinfo_notifications"];
         };
-        if (!(_informant getVariable ["KPLIB_civinfo_under_control", false]) && !alive _informant) exitWith {
+        if (!alive _informant && !KPLIB_civinfo_under_control) exitWith {
             if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_loop is reset by: %1 - Informant isn't alive", debug_source], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
             [3] remoteExec ["civinfo_notifications"];
         };

--- a/Missionframework/scripts/server/civrep/fnc/f_kp_cr_woundedAnim.sqf
+++ b/Missionframework/scripts/server/civrep/fnc/f_kp_cr_woundedAnim.sqf
@@ -8,5 +8,5 @@ Play random wounded animation on given unit
 params ["_unit"];
 
 private _anim = selectRandom ["Acts_CivilInjuredHead_1", "Acts_CivilInjuredArms_1", "Acts_CivilInjuredChest_1", "Acts_CivilInjuredLegs_1", "Acts_CivilInjuredGeneral_1", "Acts_SittingWounded_loop"];
-[_unit, _anim] remoteExecCall ["switchMove"]; 
-[_unit, _anim] remoteExecCall ["playMoveNow"]; 
+[_unit, _anim] remoteExecCall ["switchMove"];
+[_unit, _anim] remoteExecCall ["playMoveNow"];

--- a/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
+++ b/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
@@ -17,6 +17,7 @@ for "_i" from 1 to _count do {
     private _civ = [selectRandom KPLIB_c_units, _pos, _grp] call KPLIB_fnc_createManagedUnit;
     _civ setDamage 0.75;
     _civs pushBack _civ;
+};
 
 waitUntil {count _civs isEqualTo _count};
 if (KPLIB_civrep_debug > 0) then {[format ["civrep_wounded_civs.sqf -> Spawned %1 wounded civilians at %2", _count, markerText _sector], "CIVREP"] remoteExecCall ["KPLIB_fnc_log", 2];};
@@ -39,16 +40,13 @@ _waypoint setWaypointType "HOLD";
     _marker setMarkerColor "ColorCIV";
     _marker setMarkerAlpha 0.35;
     _markers pushBack _marker;
-};
 } forEach _civs;
 
-private _units_near = [markerPos _sector, 300, KPLIB_side_player] call KPLIB_fnc_getUnitsCount;
 private _range = KPLIB_range_sectorCapture*2; // default 350m
 private _units_near = [markerPos _sector, _range, KPLIB_side_player] call KPLIB_fnc_getUnitsCount;
 private _healed_civs = [];
 
 while {true} do {
-    _units_near = [markerPos _sector, 300, KPLIB_side_player] call KPLIB_fnc_getUnitsCount;
     _units_near = [markerPos _sector, _range, KPLIB_side_player] call KPLIB_fnc_getUnitsCount;
     if (_units_near isEqualTo 0) exitWith {
         if (KPLIB_civrep_debug > 0) then {["civrep_wounded_civs.sqf -> no near blufor units. exit heal wait loop", "CIVREP"] remoteExecCall ["KPLIB_fnc_log", 2]};
@@ -64,6 +62,7 @@ while {true} do {
                 _healed_civs pushBack _civx;
                 removeAllActions _civx;
                 if (alive _civx) then {
+                    private _nearestPlayer = player;
                     private _minDistance = 100;
                     {
                         private _playerx = _x;
@@ -80,7 +79,6 @@ while {true} do {
                     _civx doFollow leader group _civx;
                     _civx stop false;
                     _civx enableAI "ALL";
-                    [4, [(name _civx)]] remoteExec ["KPLIB_fnc_crGlobalMsg"];
                     [4, [(name _civx), (name _nearestPlayer)]] remoteExec ["KPLIB_fnc_crGlobalMsg"];
                     [KPLIB_cr_wounded_gain] call F_cr_changeCR;
                     stats_civilians_healed = stats_civilians_healed +1;

--- a/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
+++ b/Missionframework/scripts/server/civrep/wounded/civrep_wounded_civs.sqf
@@ -17,6 +17,12 @@ for "_i" from 1 to _count do {
     private _civ = [selectRandom KPLIB_c_units, _pos, _grp] call KPLIB_fnc_createManagedUnit;
     _civ setDamage 0.75;
     _civs pushBack _civ;
+    private _marker = createMarker ["wounded_marker_" + str _i, [((_pos select 0) - 20 + (random 40)),((_pos select 1) - 20 + (random 40))]];
+    _marker setMarkerShape "ELLIPSE";
+    _marker setMarkerSize [25,25];
+    _marker setMarkerColor "ColorCIV";
+    _marker setMarkerAlpha 0.35;
+    _markers pushBack _marker;
 };
 
 waitUntil {count _civs isEqualTo _count};
@@ -34,12 +40,6 @@ _waypoint setWaypointType "HOLD";
     _civx setDir (random 360);
     _civx call F_cr_woundedAnim;
     if (KPLIB_ace_med) then {[_civx] remoteExec ["KPLIB_fnc_crAddAceAction"];};
-    private _marker = createMarker ["wounded_marker_" + str _i, [((_pos select 0) - 20 + (random 40)),((_pos select 1) - 20 + (random 40))]];
-    _marker setMarkerShape "ELLIPSE";
-    _marker setMarkerSize [25,25];
-    _marker setMarkerColor "ColorCIV";
-    _marker setMarkerAlpha 0.35;
-    _markers pushBack _marker;
 } forEach _civs;
 
 private _range = KPLIB_range_sectorCapture*2; // default 350m

--- a/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
+++ b/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
@@ -32,7 +32,7 @@ while { KPLIB_endgame == 0 } do {
 
         private _sectors_spawn = [];
         {
-            if ( _sector_spawn_pos distance (markerpos _x) < 2500) then {
+            if ((_sector_spawn_pos distance (markerpos _x) < KPLIB_range_pointActivation) && (_sector_spawn_pos distance (markerpos _x) > (KPLIB_range_pointActivation*3))) then {
                 _sectors_spawn pushBack _x;
             };
         } foreach (KPLIB_sectors_all - (KPLIB_sectors_player + KPLIB_sectors_active));

--- a/Missionframework/scripts/server/patrols/manage_patrols.sqf
+++ b/Missionframework/scripts/server/patrols/manage_patrols.sqf
@@ -3,10 +3,15 @@ scriptName "manage_patrols";
 _combat_triggers = [20,40,50,65,80,95];
 if ( KPLIB_param_unitcap < 0.9 ) then { _combat_triggers = [20,45,90]; };
 if ( KPLIB_param_unitcap > 1.3 ) then { _combat_triggers = [15,25,40,65,75,85,95]; };
-
+/*
 _combat_triggers_infantry = [15,35,45,60,70,85];
 if ( KPLIB_param_unitcap < 0.9 ) then { _combat_triggers_infantry = [15,40,80]; };
 if ( KPLIB_param_unitcap > 1.3 ) then { _combat_triggers_infantry = [10,20,35,55,70,80,90]; };
+*/
+
+_combat_triggers_infantry = [15,45,75,90];
+if ( KPLIB_param_unitcap < 0.9 ) then { _combat_triggers_infantry = [15,60]; };
+if ( KPLIB_param_unitcap > 1.3 ) then { _combat_triggers_infantry = [10,35,60,80,90]; };
 
 sleep 5;
 

--- a/Missionframework/scripts/server/remotecall/sector_liberated_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/sector_liberated_remote_call.sqf
@@ -67,6 +67,6 @@ if (KPLIB_endgame == 0) then {
         }
         && {[] call KPLIB_fnc_getOpforCap < KPLIB_cap_battlegroup}
     ) then {
-        [_liberated_sector, (random 100) < 45] spawn spawn_battlegroup;
+        [_liberated_sector, (random 100) < 15] spawn spawn_battlegroup;
     };
 };

--- a/Missionframework/scripts/server/sector/manage_one_sector.sqf
+++ b/Missionframework/scripts/server/sector/manage_one_sector.sqf
@@ -205,13 +205,13 @@ if ((!(_sector in KPLIB_sectors_player)) && (([markerPos _sector, [_opforcount, 
     {
         if (_x isEqualTo "Turret_Array_Empty") exitWith {};
         _vehicle = [_sectorpos, _x] call KPLIB_fnc_spawnVehicle;
-        if ((_x in KPLIB_o_turrets_MORTAR) && _lambsEnable) then {
-            [group ((crew _vehicle) select 0)] call lambs_wp_fnc_taskArtilleryRegister;
-        };
         [group ((crew _vehicle) select 0),_sectorpos] spawn add_defense_waypoints;
         _managed_units pushback _vehicle;
         {_managed_units pushback _x;} foreach (crew _vehicle);
         sleep 0.25;
+        if ((_x in KPLIB_o_turrets_MORTAR) && _lambsEnable) then {
+            [group ((crew _vehicle) select 0)] call lambs_wp_fnc_taskArtilleryRegister;
+        };
     } forEach _vehtospawn;
 
     if (_building_ai_max > 0) then {

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -6280,10 +6280,10 @@
             <Portuguese>Civis estão reclamando sobre %1 construções destruídas</Portuguese>
             <Korean>민간인들이 %1 건물이 파괴된 것에 대해 불평하고 있다. </Korean>
             <Czech>Civilisté si stěžují na %1 zničené budovy.</Czech>
-            <Japanese>市民の家財が %1 個所破壊されました。</Japanese>
+            <Japanese>市民は彼らの家財が %1 個所破壊されたと苦情を伝えています。</Japanese>
         </Key>
         <Key ID="STR_CR_HEALMSG">
-            <Original>Civilian named %1 is thankful for your help.</Original>
+            <Original>Civilian named %1 is thankful to %2 for help.</Original>
             <German>Der Zivilist %1 ist dankbar für die Hilfe.</German>
             <Spanish>El civil %1 se siente agradecido por tu ayuda.</Spanish>
             <Russian>Гражданский %1 благодарен за вашу помощь.</Russian>
@@ -6292,7 +6292,11 @@
             <Chinese>平民 %1 感謝你的幫助。</Chinese>
             <Korean>시민 %1 가 도와줘서 고맙다고 인사한다. </Korean>
             <Czech>Civilista jménem %1 ti děkuje za pomoc.</Czech>
-            <Japanese>民間人 %1 は感謝の意を述べています。</Japanese>
+            <Japanese>民間人 %1 が %2 に感謝の意を表しています。</Japanese>
+        </Key>
+        <Key ID="STR_CR_HELPMSG">
+            <Original>%1 citizens of %2 are injured and need help.</Original>
+            <Japanese>%2 の民間人 %1名 が負傷し助けを要しています。</Japanese>
         </Key>
         <Key ID="STR_PARAM_CR_BUILDING">
             <Original>Civil Reputation penalty for buildings if building is</Original>


### PR DESCRIPTION
### BugFix:
- Wound civilian finally never moving before getting heal.
[Update CivWound](https://github.com/Apricot-ale/KP-Liberation-APR/commit/5de3227188c2cc5ca68533e0bc4c39cc081abd19)
[hotfix civwound](https://github.com/Apricot-ale/KP-Liberation-APR/pull/21/commits/b7571d2b06c1e5dba397013dbffd0c11e2648346)
[HotFix wounded civ](https://github.com/Apricot-ale/KP-Liberation-APR/pull/21/commits/534218f3487634eb7348bf7436e3fdebd0d89f12)
- Informant fix, it's not final fix but maybe works. or not. please work.
[Fix manybugs with informant](https://github.com/Apricot-ale/KP-Liberation-APR/commit/092f8964f6e43d8427faeacaf9a50c51ae38353d)
[Finaly fix civinformant (maybe)](https://github.com/Apricot-ale/KP-Liberation-APR/commit/71aa978e10c5105d60aafddcb1b4f5948524eaf4)
- Fix fuel/ammo containers shown in map when EnemyFOBAttack. This caused by Case-Sensitive.
[Fix mapmarker ignoreList](https://github.com/Apricot-ale/KP-Liberation-APR/commit/ee7aab734f22e9d7fc70cd72ed4b1f0d9a3b5343)

### Improve:
- Add ACE Refuel/Rearm/Repair to not ACE supported vehicles. PRACS vehicles are not support ACE.
[Add ace refuel/rearm/repair for defined vehicles](https://github.com/Apricot-ale/KP-Liberation-APR/commit/c7ab5ae84aa2360abacb7154df84b4935f6054de)
[hotfix wrong math for fuelcargo check](https://github.com/Apricot-ale/KP-Liberation-APR/pull/21/commits/1884bf95ffb5fbce3e48059761bba9c452988b6b)
- Make shown the CUP MH-47 FuelProbe from objectInit. that cool, right?
[Add CUP MH-47 Animation](https://github.com/Apricot-ale/KP-Liberation-APR/commit/c99e9483bbb755114d2fc074440b52db0d29e24a)
- Better LAMBS Garrison/ACE UnGarrison Support to enemy building defenders. When using LAMBS, you need the search house by house in sector because they never get off to outdoor. It's wasted the time.
[Better LAMBS/ACE Garrison support](https://github.com/Apricot-ale/KP-Liberation-APR/commit/080d613bc7c3277621648b616800cdf5bbb8c90c)
- Surrender is now called from global. Because sometime not works.
[Better surrender works](https://github.com/Apricot-ale/KP-Liberation-APR/commit/47f7f457b4ae9ca4dca0090a8935e02880a9116a)

### Nerf/Buff:
- Patrol spawn range is too far so it's made closer and set far limit.
[Change Inf patrol spawn range](https://github.com/Apricot-ale/KP-Liberation-APR/commit/1268f119c05c04ce34ac6e72c96c48f229aa9321)
- Patrol/Reinforcement Infantry is TOO MANY and they never contact to player always. so, I reduce the spawns.
[Reduce Infantry Patrol/Reinforcement Spam](https://github.com/Apricot-ale/KP-Liberation-APR/commit/3fe66df7fdf0c515de20a8b66503eaa65c3f4f4f)