### PR TITLE
Minor Update 240711

### DIFF
--- a/Missionframework/scripts/server/ai/building_defence_ai.sqf
+++ b/Missionframework/scripts/server/ai/building_defence_ai.sqf
@@ -5,7 +5,8 @@ params ["_unit", ["_sector", ""]];
 private _sectorPos = (markerPos _sector);
 //Check LAMBS_Danger.fsm is running. if running, skip KPLIB built in troop garrisoning and call lambs wp garrisoning.
 if (isClass (configfile >> "CfgPatches" >> "lambs_wp")) then {
-    [_unit, _sectorPos, (KPLIB_range_sectorCapture / 3 * 2), [], true, false, -1, false] call lambs_wp_fnc_taskGarrison;
+    _taskRange = round (KPLIB_range_sectorCapture / 3 * 2);
+    [_unit, _sectorPos, _taskRange, [], true, false, -1, false] call lambs_wp_fnc_taskGarrison;
 
     private _move_is_disabled = true;
     private _hostiles = 0;

--- a/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
+++ b/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
@@ -126,14 +126,14 @@ while {true} do {
         
         waitUntil {!alive _informant || _timeover};
         
-        if (_timeover) exitWith {
+        if (!alive _informant && !KPLIB_civinfo_under_control) then {
+            if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_loop is reset by: %1 - Informant isn't alive", debug_source], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
+            [3] remoteExec ["civinfo_notifications"];
+        };
+        if (_timeover) then {
             if (isNull objectParent _informant) then {deleteVehicle _informant} else {(objectParent _informant) deleteVehicleCrew _informant};
             if (KPLIB_civinfo_debug > 0) then {["Informant despawned", "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
             [2] remoteExec ["civinfo_notifications"];
-        };
-        if (!alive _informant && !KPLIB_civinfo_under_control) exitWith {
-            if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_loop is reset by: %1 - Informant isn't alive", debug_source], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
-            [3] remoteExec ["civinfo_notifications"];
         };
     } else {
         if (KPLIB_civinfo_debug > 0) then {["Informant spawn chance missed", "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};

--- a/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
+++ b/Missionframework/scripts/server/civinformant/civinfo_loop.sqf
@@ -126,11 +126,11 @@ while {true} do {
         
         waitUntil {!alive _informant || _timeover};
         
-        if (!alive _informant && !KPLIB_civinfo_under_control) then {
+        if (!alive _informant && !KPLIB_civinfo_under_control) exitWith {
             if (KPLIB_civinfo_debug > 0) then {[format ["civinfo_loop is reset by: %1 - Informant isn't alive", debug_source], "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
             [3] remoteExec ["civinfo_notifications"];
         };
-        if (_timeover) then {
+        if (_timeover) exitWith {
             if (isNull objectParent _informant) then {deleteVehicle _informant} else {(objectParent _informant) deleteVehicleCrew _informant};
             if (KPLIB_civinfo_debug > 0) then {["Informant despawned", "CIVINFO"] remoteExecCall ["KPLIB_fnc_log", 2];};
             [2] remoteExec ["civinfo_notifications"];

--- a/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
+++ b/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
@@ -20,7 +20,7 @@ while { KPLIB_endgame == 0 } do {
 
     _spawn_marker = "";
     while { _spawn_marker == "" } do {
-        _spawn_marker = [(KPLIB_range_pointActivation*1),(KPLIB_range_pointActivation*4),true] call KPLIB_fnc_getOpforSpawnPoint;
+        _spawn_marker = [1500,4000,true] call KPLIB_fnc_getOpforSpawnPoint;
         if ( _spawn_marker == "" ) then {
             sleep (150 + (random 150));
         };

--- a/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
+++ b/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
@@ -32,7 +32,7 @@ while { KPLIB_endgame == 0 } do {
 
         private _sectors_spawn = [];
         {
-            if ((_sector_spawn_pos distance (markerpos _x) < KPLIB_range_pointActivation) && (_sector_spawn_pos distance (markerpos _x) > (KPLIB_range_pointActivation*3))) then {
+            if ((_sector_spawn_pos distance (markerpos _x) > round (KPLIB_range_pointActivation / 0.5)) && (_sector_spawn_pos distance (markerpos _x) < round (KPLIB_range_pointActivation * 3))) then {
                 _sectors_spawn pushBack _x;
             };
         } foreach (KPLIB_sectors_all - (KPLIB_sectors_player + KPLIB_sectors_active));

--- a/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
+++ b/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
@@ -18,9 +18,12 @@ while { KPLIB_endgame == 0 } do {
 
     _grp = grpNull;
 
+    private _minSpawnRange = round (KPLIB_range_pointActivation * 0.5);
+    private _maxSpawnRange = round (KPLIB_range_pointActivation * 4);
+
     _spawn_marker = "";
     while { _spawn_marker == "" } do {
-        _spawn_marker = [(KPLIB_range_pointActivation*1),(KPLIB_range_pointActivation*4),true] call KPLIB_fnc_getOpforSpawnPoint;
+        _spawn_marker = [_minSpawnRange,_maxSpawnRange,true] call KPLIB_fnc_getOpforSpawnPoint;
         if ( _spawn_marker == "" ) then {
             sleep (150 + (random 150));
         };
@@ -30,9 +33,12 @@ while { KPLIB_endgame == 0 } do {
 
     if (_is_infantry) then {
 
+        private _minRange = round (KPLIB_range_pointActivation * 0.75);
+        private _maxRange = round (KPLIB_range_pointActivation * 3);
+
         private _sectors_spawn = [];
         {
-            if ((_sector_spawn_pos distance (markerpos _x) > round (KPLIB_range_pointActivation / 0.5)) && (_sector_spawn_pos distance (markerpos _x) < round (KPLIB_range_pointActivation * 3))) then {
+            if ((_sector_spawn_pos distance (markerpos _x) > _minRange) && (_sector_spawn_pos distance (markerpos _x) < _maxRange)) then {
                 _sectors_spawn pushBack _x;
             };
         } foreach (KPLIB_sectors_all - (KPLIB_sectors_player + KPLIB_sectors_active));

--- a/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
+++ b/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
@@ -20,7 +20,7 @@ while { KPLIB_endgame == 0 } do {
 
     _spawn_marker = "";
     while { _spawn_marker == "" } do {
-        _spawn_marker = [1500,4000,true] call KPLIB_fnc_getOpforSpawnPoint;
+        _spawn_marker = [(KPLIB_range_pointActivation*1),(KPLIB_range_pointActivation*4),true] call KPLIB_fnc_getOpforSpawnPoint;
         if ( _spawn_marker == "" ) then {
             sleep (150 + (random 150));
         };

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -67,7 +67,7 @@
             <Portuguese>Libere a região da opressão inimiga! Estratégia será essencial! Boa sorte infantaria.</Portuguese>
             <Korean>적의 수중에서 이 지역을 탈환하자! 전략이 승리의 관건이다! 병사들이여, 행운을 빈다.</Korean>
             <Czech>Osvoboďte oblast od nepřátelského útisku. Strategie je klíčová! Hodně štěstí vojáci.</Czech>
-            <Japanese>この地域を敵軍の圧制から解放しろ!戦略がカギとなるぞ!兵士よ、幸運を祈る。</Japanese>
+            <Japanese>この地域を敵軍の圧制から解放しろ! 戦略がカギとなるぞ! 兵士よ、幸運を祈る。</Japanese>
         </Key>
         <Key ID="STR_MISSION_PRESENT">
             <Original>[GREUH] and the Killah Potatoes present</Original>
@@ -1050,7 +1050,7 @@
             <Portuguese>Próximo de</Portuguese>
             <Korean>부근</Korean>
             <Czech>Blízko</Czech>
-            <Japanese>近くに</Japanese>
+            <Japanese>直近に</Japanese>
         </Key>
         <Key ID="STR_RECYCLE">
             <Original>-- RECYCLE</Original>
@@ -1125,7 +1125,7 @@
             <Portuguese>Cancelar</Portuguese>
             <Korean>취소</Korean>
             <Czech>Zrušit</Czech>
-            <Japanese>やめる</Japanese>
+            <Japanese>取り消し</Japanese>
         </Key>
         <Key ID="STR_NOTIFICATION_SECTORCAPTURED_TITLE">
             <Original>SECTOR CAPTURED</Original>
@@ -3075,7 +3075,7 @@
             <Portuguese>-- MOBILIZAR FOB --</Portuguese>
             <Korean>-- 전초기지 재배치 --</Korean>
             <Czech>-- ZABALIT FOB --</Czech>
-            <Japanese>-- FOBを収納する --</Japanese>
+            <Japanese>-- FOBを撤収する --</Japanese>
         </Key>
         <Key ID="STR_FOB_REPACKAGE_TITLE">
             <Original>REPACKAGE FOB</Original>
@@ -3090,7 +3090,7 @@
             <Portuguese>MOBILIZAR FOB</Portuguese>
             <Korean>전초기지 재배치</Korean>
             <Czech>ZABALIT FOB</Czech>
-            <Japanese>FOBを収納します</Japanese>
+            <Japanese>FOBを撤収します</Japanese>
         </Key>
         <Key ID="STR_FOB_REPACKAGE_CONFIRM">
             <Original>Are you sure you want to repackage this FOB?</Original>
@@ -3105,7 +3105,7 @@
             <Portuguese>Você tem certeza que quer mobilizar esta FOB?</Portuguese>
             <Korean>이 전초기지를 재배치하시겠습니까?</Korean>
             <Czech>Jste si jistý že chcete zabalit FOB?</Czech>
-            <Japanese>FOBを収納しますか?</Japanese>
+            <Japanese>FOBを撤収しますか?</Japanese>
         </Key>
         <Key ID="STR_HALO_PARAM">
             <Original>HALO Jump</Original>
@@ -7552,7 +7552,7 @@
             <Italian>FOB ripiegata.\nL'autorizzazione eventualmente creata verrà ripristinata al riavvio del server.</Italian>
             <Korean>FOB가 재포장됩니다. 이 상태로 서버 재시작시 이 부근의 건물이나 장비들은 사라집니다.</Korean>
             <Czech>FOB je zabalen.\Po restartování serveru bude pravděpodobně vytvořené oprávnění zrušeno.</Czech>
-            <Japanese>FOBを収納しました。\n設置可能範囲はリスタートまで復活しない場合があります。</Japanese>
+            <Japanese>FOBを撤収しました。\n設置可能範囲はリスタートまで復活しない場合があります。</Japanese>
         </Key>
         <Key ID="STR_FOG_PARAM">
             <Original>Dynamic fog (A3 Vanilla)</Original>


### PR DESCRIPTION
Today is 711. Go seven-eleven and buy burrito.
### BugFix:
- Fixed a bug where patrol spawn locations were always false, and nothing was selected. This was caused by placing the less/than signs wrong way round.
[Fix signs set wrong way](https://github.com/Apricot-ale/KP-Liberation-APR/commit/84e1d69a66fc0b58f94f1112280ad8ebca1333bd)
### Improve/Tweak:
- Update Japanese for who can't read English. Yeah that my friends.
[Update Localization Japanese](https://github.com/Apricot-ale/KP-Liberation-APR/commit/25aafb4e3dd847934a9c872dcdc0e8e9230e9eb6)
- Round the number of garrison range.
[round range for taskgarrison](https://github.com/Apricot-ale/KP-Liberation-APR/commit/3dd3625e735539be9b93a9b840356168b9651206)
### Nerf/Buff:
- Search range for patrol spawn points has been changed from 1000m-4000m to 500m-4000m by default and is now pre-calculated and defined to reduce the load of unnecessary recalculations.
[Update manage_one_patrol.sqf](https://github.com/Apricot-ale/KP-Liberation-APR/commit/4fdf2653aa2713e88f8bf823cfe2537db654de24)
- Search range for infantry spawn sector has been changed from 1000m-3000m to 750m-3000m by default and is now pre-calculated and defined to reduce the load of unnecessary recalculations.
[Update manage_one_patrol.sqf](https://github.com/Apricot-ale/KP-Liberation-APR/commit/4fdf2653aa2713e88f8bf823cfe2537db654de24)